### PR TITLE
fix(app): rename project from mantine-vite-template to budget-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mantine-vite-template",
+  "name": "budget-app",
   "private": true,
   "type": "module",
   "version": "0.0.0",


### PR DESCRIPTION
## Summary
Rename project from mantine-vite-template to budget-app.

## Changes
- Update `package.json`

## Testing
- Not specified

## Notes
- None
