### PR TITLE
chore: fix code review warnings for i18n, dead code, and theme migration

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost, apiPut } from './client';
+import { apiGet, apiPost } from './client';
 import { AccountLockedError, ApiError, RateLimitError } from './errors';
 
 function errorWithCause(message: string, cause: unknown): Error {
@@ -14,12 +14,6 @@ export interface RegisterRequest {
   name: string;
   email: string;
   password: string;
-}
-
-export interface UpdateUserRequest {
-  name: string;
-  email: string;
-  password?: string;
 }
 
 export interface User {
@@ -115,35 +109,6 @@ export async function fetchCurrentUser(): Promise<User> {
   }
 
   return user;
-}
-
-/**
- * Updates a user's profile information.
- * @throws Error with user-friendly message on failure
- */
-export async function updateUser(id: string, data: UpdateUserRequest): Promise<User> {
-  try {
-    return await apiPut<User, UpdateUserRequest>(`/api/auth/users/${id}`, data);
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (error.status === 400) {
-        throw errorWithCause(error.message || 'Invalid data. Please check your inputs.', error);
-      }
-      if (error.status >= 500) {
-        throw errorWithCause('Server error. Please try again later.', error);
-      }
-      if (error.message) {
-        throw errorWithCause(error.message, error);
-      }
-    }
-    if (error instanceof Error && error.message.includes('Failed to fetch')) {
-      throw errorWithCause(
-        'Unable to connect to the server. Please check your internet connection.',
-        error
-      );
-    }
-    throw errorWithCause('Update failed. Please try again.', error);
-  }
 }
 
 /**

--- a/src/locales/v2/en.json
+++ b/src/locales/v2/en.json
@@ -248,7 +248,10 @@
         "useAuthenticator": "Use authenticator code instead",
         "useRecovery": "Or use a recovery code",
         "verify": "Verify"
-      }
+      },
+      "waitSeconds": "Wait {{seconds}}s",
+      "accountLockedAlert": "Your account has been temporarily locked due to too many failed attempts. Check your email for unlock instructions.",
+      "tooManyAttemptsAlert": "Too many failed attempts. Please wait {{seconds}} seconds before trying again."
     },
     "register": {
       "agreeToTermsPrefix": "I agree to the",
@@ -338,7 +341,10 @@
       "title": "Enter verification code",
       "useAuthenticator": "Use authenticator code instead",
       "useRecoveryCode": "Or use a recovery code",
-      "verifyButton": "Verify"
+      "verifyButton": "Verify",
+      "waitSeconds": "Wait {{seconds}}s",
+      "accountLocked": "Your account has been temporarily locked due to too many failed attempts. Check your email for unlock instructions.",
+      "tooManyAttempts": "Too many failed attempts. Please wait {{seconds}} seconds before trying again."
     },
     "unlock": {
       "errorMessage": "This link has expired or is invalid.",
@@ -630,6 +636,8 @@
     },
     "customize": "Customize",
     "done": "Done",
+    "emptyTitle": "No widgets to show",
+    "emptyDescription": "Use the Customize button to add widgets to your dashboard.",
     "fixedCategories": {
       "categoryCount": "{{count}} {{label}}",
       "count_one": "{{count}} category",

--- a/src/locales/v2/pt.json
+++ b/src/locales/v2/pt.json
@@ -248,7 +248,10 @@
         "useAuthenticator": "Usar código do autenticador",
         "useRecovery": "Ou usar um código de recuperação",
         "verify": "Verificar"
-      }
+      },
+      "waitSeconds": "Aguarde {{seconds}}s",
+      "accountLockedAlert": "A sua conta foi temporariamente bloqueada devido a demasiadas tentativas falhadas. Verifique o seu email para instruções de desbloqueio.",
+      "tooManyAttemptsAlert": "Demasiadas tentativas falhadas. Aguarde {{seconds}} segundos antes de tentar novamente."
     },
     "register": {
       "agreeToTermsPrefix": "Concordo com os",
@@ -346,7 +349,10 @@
       "title": "Introduza o código de verificação",
       "useAuthenticator": "Usar código do autenticador",
       "useRecoveryCode": "Ou usar um código de recuperação",
-      "verifyButton": "Verificar"
+      "verifyButton": "Verificar",
+      "waitSeconds": "Aguarde {{seconds}}s",
+      "accountLocked": "A sua conta foi temporariamente bloqueada devido a demasiadas tentativas falhadas. Verifique o seu email para instruções de desbloqueio.",
+      "tooManyAttempts": "Demasiadas tentativas falhadas. Aguarde {{seconds}} segundos antes de tentar novamente."
     },
     "unlock": {
       "errorMessage": "Este link expirou ou é inválido.",
@@ -638,6 +644,8 @@
     },
     "customize": "Personalizar",
     "done": "Concluir",
+    "emptyTitle": "Sem widgets para mostrar",
+    "emptyDescription": "Use o botão Personalizar para adicionar widgets ao seu painel.",
     "fixedCategories": {
       "categoryCount": "{{count}} {{label}}",
       "count_one": "{{count}} categoria",

--- a/src/pages/v2/Settings.page.tsx
+++ b/src/pages/v2/Settings.page.tsx
@@ -103,12 +103,6 @@ export function SettingsV2Page() {
   );
   const [compactMode, setCompactMode] = useState(false);
 
-  // ── Local state (dashboard widgets) ──
-  const [_hiddenWidgets, setHiddenWidgets] = useState<string[]>([]);
-  const [_widgetOrder, setWidgetOrder] = useState<string[]>([]);
-  // null = show all active accounts (default); string[] = show only these account IDs
-  const [_visibleAccountIds, setVisibleAccountIds] = useState<string[] | null>(null);
-
   // ── Local state (security modals) ──
   const [passwordModalOpen, passwordModal] = useDisclosure(false);
   const [currentPassword, setCurrentPassword] = useState('');
@@ -170,11 +164,6 @@ export function SettingsV2Page() {
       if (prefs.colorTheme) {
         setColorTheme(prefs.colorTheme as ColorTheme);
       }
-      if (prefs.dashboardLayout) {
-        setHiddenWidgets(prefs.dashboardLayout.hiddenWidgets ?? []);
-        setWidgetOrder(prefs.dashboardLayout.widgetOrder ?? []);
-        setVisibleAccountIds(prefs.dashboardLayout.visibleAccountIds ?? null);
-      }
     }
   }, [preferencesQuery.data, setColorTheme]);
 
@@ -216,6 +205,13 @@ export function SettingsV2Page() {
     },
     [setColorScheme, updatePrefsMut, language, dateFormat, numberFormat, colorTheme, compactMode]
   );
+
+  // ── Migrate users off removed "system" scheme ──
+  useEffect(() => {
+    if (scheme === 'system' || (colorScheme as string) === 'auto') {
+      void handleSchemeChange('dark');
+    }
+  }, [scheme, colorScheme, handleSchemeChange]);
 
   const handleThemeChange = useCallback(
     async (theme: ColorTheme) => {


### PR DESCRIPTION
## Summary

- **Missing i18n keys**: Added translation keys for login rate-limiting (`waitSeconds`, `accountLockedAlert`, `tooManyAttemptsAlert`), 2FA lockout (`waitSeconds`, `accountLocked`, `tooManyAttempts`), and empty dashboard state (`emptyTitle`, `emptyDescription`) in both `en.json` and `pt.json`
- **Dead state variables**: Removed `_hiddenWidgets`, `_widgetOrder`, `_visibleAccountIds` useState declarations and their setter calls from `Settings.page.tsx` (leftover from Dashboard Customization removal)
- **System theme escape hatch**: Added a `useEffect` in Settings that auto-migrates users with `system`/`auto` color scheme to `dark`, preventing them from being stuck on a removed option
- **Dead `updateUser` function**: Removed `updateUser` and `UpdateUserRequest` from `auth.ts` (not imported anywhere; endpoint does not exist in v2)

## Test plan

- [x] `yarn prettier:write` passes
- [x] `npx tsc --noEmit` passes (no type errors)
- [x] `yarn vitest --run` passes (170/170 tests)
- [x] Pre-commit hooks (typecheck, prettier, lint, vitest) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)