### PR TITLE
feat(forms): note ledger constraint on type field edits

### DIFF
--- a/src/components/v2/Accounts/AccountFormDrawer.tsx
+++ b/src/components/v2/Accounts/AccountFormDrawer.tsx
@@ -132,7 +132,14 @@ export function AccountFormDrawer({ opened, onClose, editAccountId }: AccountFor
       }}
     >
       <Stack gap="md">
-        {/* Account type selector */}
+        {/*
+          Account type is immutable after creation. The backend enforces this
+          via a BEFORE UPDATE trigger on the `account` table (migration
+          20260327000004), because account_type is snapshotted by the
+          transaction aggregate trigger at insert time to classify spending
+          (Transfer-to-Allowance). Editing it would silently drift the
+          materialized aggregates. Do not add an edit-mode branch here.
+        */}
         {!isEdit && (
           <div>
             <Text fz="xs" fw={600} tt="uppercase" c="dimmed" mb={4}>

--- a/src/components/v2/Categories/CategoryFormDrawer.tsx
+++ b/src/components/v2/Categories/CategoryFormDrawer.tsx
@@ -148,7 +148,14 @@ export function CategoryFormDrawer({ opened, onClose, editCategory }: CategoryFo
       }}
     >
       <Stack gap="md">
-        {/* Type selector */}
+        {/*
+          Category type is immutable after creation. The backend enforces this
+          via a BEFORE UPDATE trigger on the `category` table (migration
+          20260327000004), because category_type is snapshotted by the
+          transaction aggregate trigger at insert time to classify
+          inflow/outflow/spending. Editing it would silently drift the
+          materialized aggregates. Do not add an edit-mode branch here.
+        */}
         {!isEdit && (
           <div>
             <Text fz="xs" fw={600} tt="uppercase" c="dimmed" mb={4}>


### PR DESCRIPTION
## Summary

Pairs with https://github.com/leocalm/piggy-pulse-api/pull/311 (immutable transaction ledger refactor).

The backend now enforces that \`category.category_type\` and \`account.account_type\` are immutable after creation — these columns are snapshotted by the transaction aggregate trigger at insert time to classify inflow/outflow/spending, and editing them would silently drift the materialized aggregate tables.

Both form drawers already hide the type selector in edit mode (\`{!isEdit && (...)}\`), so the existing UX is already aligned with the new constraint. This PR adds defensive comments on both drawers documenting the backend constraint so future refactors don't add an edit-mode branch that would surface the raw trigger error (\`"category.category_type is immutable after creation"\` / \`"account.account_type is immutable after creation"\`) to users.

No behavior change.

## Test plan

- [x] \`yarn typecheck\`, \`yarn prettier\`, \`yarn lint\`, \`yarn vitest\` all green in pre-commit
- [x] Create/edit flows for categories and accounts unchanged — type selector still shows on create, still hidden on edit