### PR TITLE
chore: enabling staging to work with a different api base

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -42,7 +42,7 @@ function normalizeBasePath(basePath: string): string {
 }
 
 // Allow configuration via env: VITE_API_BASE_PATH (full path) or VITE_API_VERSION (e.g. "v1" or "1").
-function resolveApiBasePath(): string {
+export function resolveApiBasePath(): string {
   const env = import.meta.env;
   const rawVersion = env?.VITE_API_VERSION;
   const version = typeof rawVersion === 'string' ? rawVersion.trim() : undefined;

--- a/src/api/v2client.ts
+++ b/src/api/v2client.ts
@@ -1,7 +1,8 @@
 import createClient from 'openapi-fetch';
+import { resolveApiBasePath } from './client';
 import type { paths } from './v2';
 
-export const v2BaseUrl = import.meta.env.DEV ? '/api/v2' : 'https://api.piggy-pulse.com/v2';
+export const v2BaseUrl = import.meta.env.DEV ? '/v2' : resolveApiBasePath();
 
 export const apiClient = createClient<paths>({
   baseUrl: v2BaseUrl,

--- a/src/components/v2/Accounts/AccountFormDrawer.tsx
+++ b/src/components/v2/Accounts/AccountFormDrawer.tsx
@@ -132,7 +132,14 @@ export function AccountFormDrawer({ opened, onClose, editAccountId }: AccountFor
       }}
     >
       <Stack gap="md">
-        {/* Account type selector */}
+        {/*
+          Account type is immutable after creation. The backend enforces this
+          via a BEFORE UPDATE trigger on the `account` table (migration
+          20260327000004), because account_type is snapshotted by the
+          transaction aggregate trigger at insert time to classify spending
+          (Transfer-to-Allowance). Editing it would silently drift the
+          materialized aggregates. Do not add an edit-mode branch here.
+        */}
         {!isEdit && (
           <div>
             <Text fz="xs" fw={600} tt="uppercase" c="dimmed" mb={4}>

--- a/src/components/v2/Categories/CategoryFormDrawer.tsx
+++ b/src/components/v2/Categories/CategoryFormDrawer.tsx
@@ -148,7 +148,14 @@ export function CategoryFormDrawer({ opened, onClose, editCategory }: CategoryFo
       }}
     >
       <Stack gap="md">
-        {/* Type selector */}
+        {/*
+          Category type is immutable after creation. The backend enforces this
+          via a BEFORE UPDATE trigger on the `category` table (migration
+          20260327000004), because category_type is snapshotted by the
+          transaction aggregate trigger at insert time to classify
+          inflow/outflow/spending. Editing it would silently drift the
+          materialized aggregates. Do not add an edit-mode branch here.
+        */}
         {!isEdit && (
           <div>
             <Text fz="xs" fw={600} tt="uppercase" c="dimmed" mb={4}>

--- a/src/components/v2/Dashboard/AccountCard.story.tsx
+++ b/src/components/v2/Dashboard/AccountCard.story.tsx
@@ -6,9 +6,9 @@ import { AccountCard } from './AccountCard';
 
 const ACCOUNT_ID = 'mock-account-1';
 const PERIOD_ID = 'mock-period-1';
-const DETAILS_EP = '*/api/v2/accounts/*/details*';
-const HISTORY_EP = '*/api/v2/accounts/*/balance-history*';
-const ACCOUNTS_EP = '*/api/v2/accounts*';
+const DETAILS_EP = '*/v2/accounts/*/details*';
+const HISTORY_EP = '*/v2/accounts/*/balance-history*';
+const ACCOUNTS_EP = '*/v2/accounts*';
 
 const baseAccount = {
   id: ACCOUNT_ID,

--- a/src/components/v2/Dashboard/CurrentPeriodCard.story.tsx
+++ b/src/components/v2/Dashboard/CurrentPeriodCard.story.tsx
@@ -9,9 +9,9 @@ type CurrentPeriod = components['schemas']['CurrentPeriod'];
 type CurrentPeriodHistoryPoint = components['schemas']['CurrentPeriodHistoryPoint'];
 
 const PERIOD_ID = 'mock-period-1';
-const CP_ENDPOINT = '*/api/v2/dashboard/current-period*';
-const CP_HISTORY_ENDPOINT = '*/api/v2/dashboard/current-period-history*';
-const PERIODS_ENDPOINT = '*/api/v2/periods*';
+const CP_ENDPOINT = '*/v2/dashboard/current-period*';
+const CP_HISTORY_ENDPOINT = '*/v2/dashboard/current-period-history*';
+const PERIODS_ENDPOINT = '*/v2/periods*';
 
 const mockPeriod = {
   data: [

--- a/src/components/v2/Dashboard/NetPositionCard.story.tsx
+++ b/src/components/v2/Dashboard/NetPositionCard.story.tsx
@@ -9,8 +9,8 @@ type NetPosition = components['schemas']['NetPosition'];
 type AccountSummaryResponse = components['schemas']['AccountSummaryResponse'];
 
 const PERIOD_ID = 'mock-period-1';
-const ENDPOINT = '*/api/v2/dashboard/net-position*';
-const ACCOUNTS_ENDPOINT = '*/api/v2/accounts/summary*';
+const ENDPOINT = '*/v2/dashboard/net-position*';
+const ACCOUNTS_ENDPOINT = '*/v2/accounts/summary*';
 
 const mockPositive: NetPosition = {
   total: 1284000,
@@ -99,7 +99,7 @@ const mockAccounts: AccountSummaryResponse[] = [
   },
 ];
 
-const HISTORY_ENDPOINT = '*/api/v2/dashboard/net-position-history*';
+const HISTORY_ENDPOINT = '*/v2/dashboard/net-position-history*';
 
 const mockHistory = [
   {

--- a/src/components/v2/PeriodSelector/PeriodSelector.story.tsx
+++ b/src/components/v2/PeriodSelector/PeriodSelector.story.tsx
@@ -63,13 +63,13 @@ const mockPeriods = {
 };
 
 const periodHandlers = [
-  http.get('*/api/v2/periods*', () => {
+  http.get('*/v2/periods*', () => {
     return HttpResponse.json(mockPeriods);
   }),
 ];
 
 const gapHandlers = [
-  http.get('*/api/v2/periods*', () => {
+  http.get('*/v2/periods*', () => {
     return HttpResponse.json({
       ...mockPeriods,
       data: mockPeriods.data.filter((p) => p.status !== 'active'),
@@ -135,7 +135,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get('*/api/v2/periods*', () => {
+        http.get('*/v2/periods*', () => {
           return HttpResponse.json({ data: [], total: 0, page: 1, pageSize: 20 });
         }),
       ],
@@ -155,7 +155,7 @@ export const Error: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get('*/api/v2/periods*', () => {
+        http.get('*/v2/periods*', () => {
           return new HttpResponse(null, { status: 500 });
         }),
       ],
@@ -175,7 +175,7 @@ export const Loading: Story = {
   parameters: {
     msw: {
       handlers: [
-        http.get('*/api/v2/periods*', async () => {
+        http.get('*/v2/periods*', async () => {
           await new Promise(() => {}); // infinite delay
         }),
       ],

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -71,11 +71,6 @@ export default defineConfig({
         target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
         changeOrigin: true,
       },
-      '/api/v2': {
-        target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api\/v2/, '/v2'),
-      },
     },
   },
 });


### PR DESCRIPTION
This pull request primarily updates the API base path handling to improve flexibility and consistency across the codebase. It introduces a utility to resolve the API base path based on environment variables, updates all relevant API endpoint usages and mock handlers to match the new path structure, and clarifies backend constraints on editing account and category types.

**API Base Path Refactoring and Consistency**

- Exported the `resolveApiBasePath` function from `src/api/client.ts` to allow dynamic resolution of the API base path using environment variables, making the API client configuration more flexible.
- Updated `src/api/v2client.ts` to use `resolveApiBasePath` for determining the `v2BaseUrl`, ensuring the API client uses the correct base path in all environments.
- Changed all mock API endpoint patterns in Storybook stories (e.g., `AccountCard.story.tsx`, `CurrentPeriodCard.story.tsx`, `NetPositionCard.story.tsx`, `PeriodSelector.story.tsx`) from `*/api/v2/...` to `*/v2/...` to match the updated API routing. [[1]](diffhunk://#diff-c46cc14deeaa9a33e331fe4fa1f4b836a50b610f3089d751a8fa7251d5edaaf5L9-R11) [[2]](diffhunk://#diff-ec11cfbe4f7752397e064623656ab0e1d9813b3fb4cc4b0da83bf70bf8f0dd3dL12-R14) [[3]](diffhunk://#diff-6aa4a1ad3a673e2f77f18757864fc48736feb12d40d67f93cf775b59a7a37ea7L12-R13) [[4]](diffhunk://#diff-6aa4a1ad3a673e2f77f18757864fc48736feb12d40d67f93cf775b59a7a37ea7L102-R102) [[5]](diffhunk://#diff-ce59def345592fdb990032d7826b5853a82060b924a078fc72593bdc6f8fd705L66-R72) [[6]](diffhunk://#diff-ce59def345592fdb990032d7826b5853a82060b924a078fc72593bdc6f8fd705L138-R138) [[7]](diffhunk://#diff-ce59def345592fdb990032d7826b5853a82060b924a078fc72593bdc6f8fd705L158-R158) [[8]](diffhunk://#diff-ce59def345592fdb990032d7826b5853a82060b924a078fc72593bdc6f8fd705L178-R178)
- Removed the `/api/v2` proxy rewrite from `vite.config.mjs`, as the API base path is now consistently `/v2` and handled by the new utility.

**Clarification of Backend Constraints**

- Added explanatory comments in `AccountFormDrawer.tsx` and `CategoryFormDrawer.tsx` to clarify that account and category types are immutable after creation, enforced by backend triggers, and should not be editable in the UI. [[1]](diffhunk://#diff-c47260af23c8f5b476cd8fde4b4a141a6eebbfd9629cc182dbc30c7659077de5L135-R142) [[2]](diffhunk://#diff-a966f522416fb9e97307ff92b9127acd4144424d842872558a9268856d0aabd0L151-R158)