### PR TITLE
fix(csp): allow wasm-unsafe-eval and Google Fonts

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -6,4 +6,4 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=(), usb=(), payment=()
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-site
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://*.piggy-pulse.com; worker-src 'self' blob:; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.piggy-pulse.com; worker-src 'self' blob:; upgrade-insecure-requests


### PR DESCRIPTION
## Summary

- Prod registration/login silently failed with the generic "Email might be in use" message and no API call visible in the network tab.
- Root cause: the CSP on the Cloudflare Pages deployment (`public/_headers`) blocked WebAssembly (`script-src 'self'` with no `'wasm-unsafe-eval'`), so the `hash-wasm` bundle used by the encryption-at-rest flow (Argon2id → KEK → wrap DEK) couldn't initialise. The register/unlock handlers threw locally and the UI showed its fallback before any POST was sent.
- Secondary: the CSP also blocked the Google Fonts stylesheet (`fonts.googleapis.com`) and font files (`fonts.gstatic.com`).

### What changed

- `script-src`: add `'wasm-unsafe-eval'` — narrow opt-in for WebAssembly. Explicitly NOT adding `'unsafe-eval'`.
- `style-src`:  add `https://fonts.googleapis.com` — for the `@import`'d stylesheet (Calistoga / JetBrains Mono / Sora).
- `font-src`:   add `https://fonts.gstatic.com` — for the font files that stylesheet pulls in.

Everything else in the policy is unchanged.

## Test plan

- [ ] Merge + wait for Cloudflare Pages prod deploy
- [ ] Hard-refresh `https://piggy-pulse.com/register` (CSP is cached aggressively; Cmd+Shift+R)
- [ ] DevTools → Console: no CSP violations on load
- [ ] Register a throwaway user → confirm `POST /api/v1/auth/register` fires in Network tab with `wrappedDek` + `dekWrapParams` in the body
- [ ] Log out, log back in → unlock succeeds, authed pages load
- [ ] DevTools → Elements: Google Fonts stylesheet and font files load without CSP errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)