### PR TITLE
feat(test): manual E2E forget password tests

### DIFF
--- a/src/components/v2/Auth/ForgotPasswordPage.tsx
+++ b/src/components/v2/Auth/ForgotPasswordPage.tsx
@@ -23,7 +23,12 @@ export function V2ForgotPasswordPage() {
     return (
       <Stack gap="md" ta="center">
         <Text fz={32}>📧</Text>
-        <Text fz={22} fw={700} ff="var(--mantine-font-family-headings)">
+        <Text
+          fz={22}
+          fw={700}
+          ff="var(--mantine-font-family-headings)"
+          data-testid="forgot-password-sent-title"
+        >
           {t('auth.forgotPassword.sentTitle')}
         </Text>
         <Text fz="sm" c="dimmed">
@@ -44,11 +49,19 @@ export function V2ForgotPasswordPage() {
               setSent(false);
               forgotMutation.reset();
             }}
+            data-testid="forgot-password-resend"
           >
             {t('auth.forgotPassword.resendLink')}
           </Anchor>
         </Text>
-        <Anchor component={Link} to="/auth/login" fz="sm" c="var(--v2-primary)" mt="md">
+        <Anchor
+          component={Link}
+          to="/auth/login"
+          fz="sm"
+          c="var(--v2-primary)"
+          mt="md"
+          data-testid="forgot-password-back-to-signin"
+        >
           {t('auth.forgotPassword.backToSignIn')}
         </Anchor>
       </Stack>
@@ -75,6 +88,7 @@ export function V2ForgotPasswordPage() {
             handleSubmit();
           }
         }}
+        data-testid="forgot-password-email"
       />
 
       <Button
@@ -83,6 +97,7 @@ export function V2ForgotPasswordPage() {
         fullWidth
         size="md"
         disabled={!email}
+        data-testid="forgot-password-submit"
       >
         {t('auth.forgotPassword.submitButton')}
       </Button>

--- a/src/components/v2/Auth/ResetPasswordPage.tsx
+++ b/src/components/v2/Auth/ResetPasswordPage.tsx
@@ -45,7 +45,12 @@ export function V2ResetPasswordPage() {
     return (
       <div className={classes.successContent}>
         <Text fz={32}>✓</Text>
-        <Text fz={22} fw={700} ff="var(--mantine-font-family-headings)">
+        <Text
+          fz={22}
+          fw={700}
+          ff="var(--mantine-font-family-headings)"
+          data-testid="reset-password-success-title"
+        >
           {t('auth.resetPassword.successTitle')}
         </Text>
         <Text fz="sm" c="dimmed">
@@ -54,7 +59,13 @@ export function V2ResetPasswordPage() {
         <Text fz="sm" c="dimmed">
           {t('auth.resetPassword.successSubtext')}
         </Text>
-        <Button component={Link} to="/auth/login" size="md" mt="md">
+        <Button
+          component={Link}
+          to="/auth/login"
+          size="md"
+          mt="md"
+          data-testid="reset-password-go-to-signin"
+        >
           {t('auth.resetPassword.goToSignIn')}
         </Button>
       </div>
@@ -64,13 +75,24 @@ export function V2ResetPasswordPage() {
   if (!token) {
     return (
       <div className={classes.successContent}>
-        <Text fz={22} fw={700} ff="var(--mantine-font-family-headings)">
+        <Text
+          fz={22}
+          fw={700}
+          ff="var(--mantine-font-family-headings)"
+          data-testid="reset-password-invalid-title"
+        >
           {t('auth.resetPassword.invalidLinkTitle')}
         </Text>
         <Text fz="sm" c="dimmed">
           {t('auth.resetPassword.invalidLinkMessage')}
         </Text>
-        <Button component={Link} to="/auth/forgot-password" size="md" mt="md">
+        <Button
+          component={Link}
+          to="/auth/forgot-password"
+          size="md"
+          mt="md"
+          data-testid="reset-password-request-new-link"
+        >
           {t('auth.resetPassword.requestNewLink')}
         </Button>
       </div>
@@ -92,6 +114,7 @@ export function V2ResetPasswordPage() {
           value={password}
           onChange={(e) => setPassword(e.currentTarget.value)}
           type="password"
+          data-testid="reset-password-new-password"
         />
         {password && <PasswordStrengthBar score={strength.score} />}
       </div>
@@ -110,6 +133,7 @@ export function V2ResetPasswordPage() {
             handleSubmit();
           }
         }}
+        data-testid="reset-password-confirm-password"
       />
 
       <Button
@@ -118,6 +142,7 @@ export function V2ResetPasswordPage() {
         fullWidth
         size="md"
         disabled={!isValid}
+        data-testid="reset-password-submit"
       >
         {t('auth.resetPassword.submitButton')}
       </Button>

--- a/tests/manual/03-forgot-password.spec.ts
+++ b/tests/manual/03-forgot-password.spec.ts
@@ -1,0 +1,85 @@
+import { createTestUserCredentials } from '../helpers/test-data';
+import { e2eEnv } from '../setup/env';
+import { expect, test } from './fixtures/manual.fixture';
+import { ForgotPasswordPage } from './pages/forgot-password.page';
+import { LoginPage } from './pages/login.page';
+import { ResetPasswordPage } from './pages/reset-password.page';
+
+test.describe('Forget password', () => {
+  test('happy path — reset password via email link allows login with new password', async ({
+    page,
+    request,
+    mailpit,
+  }) => {
+    const credentials = createTestUserCredentials(
+      `manual-forgot-happy-${test.info().workerIndex}-${Date.now()}`
+    );
+
+    // Register user via API
+    const regRes = await request.post(`${e2eEnv.apiUrl}/v2/auth/register`, {
+      data: { name: credentials.name, email: credentials.email, password: credentials.password },
+    });
+    expect(regRes.ok(), `Register failed: ${await regRes.text()}`).toBeTruthy();
+
+    await mailpit.purge();
+
+    // Submit forgot-password form
+    const forgotPage = new ForgotPasswordPage(page);
+    await forgotPage.requestReset(credentials.email);
+    await forgotPage.expectSentStateVisible();
+
+    // Wait for the reset email
+    const email = await mailpit.waitForMessage(
+      (msg) =>
+        msg.To.some((addr) => addr.Address === credentials.email) &&
+        (msg.Subject.toLowerCase().includes('reset') ||
+          msg.Subject.toLowerCase().includes('password')),
+      { timeout: 30_000 }
+    );
+
+    // Extract reset token from email body
+    const bodyText = (email as { Text?: string; HTML?: string }).Text || '';
+    const bodyHtml = (email as { Text?: string; HTML?: string }).HTML || '';
+    const source = bodyText || bodyHtml;
+
+    const tokenMatch =
+      source.match(/token=([A-Za-z0-9_-]+)/) ||
+      source.match(/\/auth\/reset-password\?token=([A-Za-z0-9_-]+)/);
+    expect(tokenMatch, 'Could not find reset token in email').toBeTruthy();
+    const resetToken = tokenMatch![1];
+
+    // Reset the password
+    const newPassword = `New-Strong-Pass-${Date.now()}!Aa1`;
+    const resetPage = new ResetPasswordPage(page);
+    await resetPage.resetPassword(resetToken, newPassword);
+    await resetPage.expectSuccessStateVisible();
+
+    // Log in with the new password
+    const loginPage = new LoginPage(page);
+    await loginPage.login(credentials.email, newPassword);
+    await expect(page).toHaveURL(/\/(dashboard|onboarding)/, { timeout: 15000 });
+  });
+
+  test('unregistered email shows the same sent state (no enumeration) and sends no email', async ({
+    page,
+    mailpit,
+  }) => {
+    const unregisteredEmail = `unregistered-${Date.now()}@example.test`;
+
+    await mailpit.purge();
+
+    const forgotPage = new ForgotPasswordPage(page);
+    await forgotPage.requestReset(unregisteredEmail);
+    await forgotPage.expectSentStateVisible();
+
+    // Wait a moment then confirm no email was delivered
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+
+    const delivered = await mailpit.searchMessages((msg) =>
+      msg.To.some((addr) => addr.Address === unregisteredEmail)
+    );
+    expect(delivered, 'No email should be sent for an unregistered address').toBeNull();
+  });
+});

--- a/tests/manual/pages/forgot-password.page.ts
+++ b/tests/manual/pages/forgot-password.page.ts
@@ -1,0 +1,43 @@
+import { expect, type Page } from 'playwright/test';
+
+export class ForgotPasswordPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/auth/forgot-password');
+    await expect(this.page.getByTestId('forgot-password-email')).toBeVisible({ timeout: 10000 });
+  }
+
+  async dismissCookieBanner(): Promise<void> {
+    await this.page
+      .getByRole('region', { name: 'Cookie consent' })
+      .getByRole('button', { name: 'Accept' })
+      .click({ timeout: 2000 })
+      .catch(() => {});
+  }
+
+  async fillEmail(email: string): Promise<void> {
+    await this.page.getByTestId('forgot-password-email').fill(email);
+  }
+
+  async submit(): Promise<void> {
+    await this.page.getByTestId('forgot-password-submit').click();
+  }
+
+  async requestReset(email: string): Promise<void> {
+    await this.goto();
+    await this.dismissCookieBanner();
+    await this.fillEmail(email);
+    await this.submit();
+  }
+
+  async expectSentStateVisible(): Promise<void> {
+    await expect(this.page.getByTestId('forgot-password-sent-title')).toBeVisible({
+      timeout: 10000,
+    });
+  }
+
+  async expectSubmitButtonDisabled(): Promise<void> {
+    await expect(this.page.getByTestId('forgot-password-submit')).toBeDisabled();
+  }
+}

--- a/tests/manual/pages/reset-password.page.ts
+++ b/tests/manual/pages/reset-password.page.ts
@@ -1,0 +1,43 @@
+import { expect, type Page } from 'playwright/test';
+
+export class ResetPasswordPage {
+  constructor(private readonly page: Page) {}
+
+  async gotoWithToken(token: string): Promise<void> {
+    await this.page.goto(`/auth/reset-password?token=${token}`);
+    await expect(this.page.getByTestId('reset-password-new-password')).toBeVisible({
+      timeout: 10000,
+    });
+  }
+
+  async fillNewPassword(password: string): Promise<void> {
+    await this.page.getByTestId('reset-password-new-password').fill(password);
+  }
+
+  async fillConfirmPassword(password: string): Promise<void> {
+    await this.page.getByTestId('reset-password-confirm-password').fill(password);
+  }
+
+  async submit(): Promise<void> {
+    await this.page.getByTestId('reset-password-submit').click();
+  }
+
+  async resetPassword(token: string, password: string): Promise<void> {
+    await this.gotoWithToken(token);
+    await this.fillNewPassword(password);
+    await this.fillConfirmPassword(password);
+    await this.submit();
+  }
+
+  async expectSuccessStateVisible(): Promise<void> {
+    await expect(this.page.getByTestId('reset-password-success-title')).toBeVisible({
+      timeout: 10000,
+    });
+  }
+
+  async expectInvalidLinkStateVisible(): Promise<void> {
+    await expect(this.page.getByTestId('reset-password-invalid-title')).toBeVisible({
+      timeout: 10000,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds two manual E2E tests for the forget-password flow under `tests/manual/03-forgot-password.spec.ts`:
  - **Happy path** — register a user, request a reset, extract the token from the Mailpit-delivered email, set a new password, then log in with it.
  - **Unregistered email (no enumeration)** — the UI shows the same "Check your email" state and Mailpit receives no message for the unknown address.
- Adds `ForgotPasswordPage` and `ResetPasswordPage` page objects matching the style of the existing login/registration page objects.
- Adds `data-testid` attributes to `ForgotPasswordPage.tsx` and `ResetPasswordPage.tsx` so the tests have stable selectors. No behavior or copy changes.

## Test plan

- [ ] `yarn typecheck` passes
- [ ] `yarn lint` passes
- [ ] Bring up the full docker stack (`docker-compose up -d`) and run `yarn e2e:manual --grep "Forget password"` — both tests pass against the real backend + Mailpit
- [ ] Manually verify in the UI that the new testids do not affect the visible appearance of the forgot/reset password pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)