### PR TITLE
fix(observability): allowlist Umami Cloud ingest in CSP

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -26,17 +26,22 @@ function cspHeadersPlugin() {
       const umamiScript = process.env.VITE_UMAMI_SCRIPT_URL;
       if (umamiScript) {
         try {
-          scriptExtra.add(new URL(umamiScript).origin);
+          const origin = new URL(umamiScript).origin;
+          scriptExtra.add(origin);
+          // Umami Cloud serves script.js from cloud.umami.is but POSTs collects
+          // to api-gateway.umami.dev. Allowlist both unless the user pinned
+          // VITE_UMAMI_HOST_URL to something specific.
+          if (new URL(umamiScript).hostname === 'cloud.umami.is') {
+            connectExtra.add('https://api-gateway.umami.dev');
+          } else {
+            connectExtra.add(origin);
+          }
         } catch {}
       }
       const umamiHost = process.env.VITE_UMAMI_HOST_URL;
       if (umamiHost) {
         try {
           connectExtra.add(new URL(umamiHost).origin);
-        } catch {}
-      } else if (umamiScript) {
-        try {
-          connectExtra.add(new URL(umamiScript).origin);
         } catch {}
       }
 


### PR DESCRIPTION
## Summary

Umami Cloud loads `script.js` from `cloud.umami.is` but POSTs collected events to a **different origin** — `https://api-gateway.umami.dev/api/send`. The CSP shipped in #380 only derived `cloud.umami.is` from `VITE_UMAMI_SCRIPT_URL`, so every hit was silently blocked by `connect-src` in production. (Confirmed by browser-console violations on `app.piggy-pulse.com`.)

This special-cases `cloud.umami.is` in the CSP plugin so deployments using Umami Cloud automatically allowlist `api-gateway.umami.dev`. Self-hosted setups are unchanged — they still derive the collect origin from `VITE_UMAMI_SCRIPT_URL`, or from an explicit `VITE_UMAMI_HOST_URL` override.

No env-var or dashboard changes required on Cloudflare Pages — the fix lands automatically on the next deploy.

## Test plan

- [x] `yarn build` with `VITE_UMAMI_SCRIPT_URL=https://cloud.umami.is/script.js` emits `connect-src ... https://api-gateway.umami.dev ...` in `dist/_headers`
- [x] `yarn build` with a self-hosted URL still derives the same origin for `connect-src`
- [x] Pre-commit hooks (typecheck, prettier, eslint, vitest) pass
- [ ] Post-merge: confirm `cloud.umami.is/api/send` requests no longer appear as CSP violations in the live console, and that page views show up in the Umami dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)