### PR TITLE
feat(feedback): in-app feedback form routed to Sentry

### DIFF
--- a/src/components/v2/AppShell/MobileHeader.tsx
+++ b/src/components/v2/AppShell/MobileHeader.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from 'react';
-import { IconLogout, IconSettings } from '@tabler/icons-react';
+import { IconLogout, IconMessage, IconSettings } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Avatar, Group, Image, Menu, Text } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { FeedbackModal } from '@/components/v2/Feedback';
 import { useAuth } from '@/context/AuthContext';
 import { useV2Theme } from '@/theme/v2';
 import classes from './AppShell.module.css';
@@ -29,6 +31,7 @@ export function MobileHeader({ userName, periodSelector }: MobileHeaderProps) {
   const { logout } = useAuth();
   const { colorTheme } = useV2Theme();
   const logoSrc = LOGO_PATHS[colorTheme] ?? LOGO_PATHS.nebula;
+  const [feedbackOpen, feedback] = useDisclosure(false);
 
   const initials = userName
     .split(' ')
@@ -76,6 +79,13 @@ export function MobileHeader({ userName, periodSelector }: MobileHeaderProps) {
             >
               {t('common.settings')}
             </Menu.Item>
+            <Menu.Item
+              leftSection={<IconMessage size={14} />}
+              onClick={feedback.open}
+              data-testid="feedback-menu-item"
+            >
+              {t('feedback.menuItem')}
+            </Menu.Item>
             <Menu.Divider />
             <Menu.Item leftSection={<IconLogout size={14} />} color="red" onClick={handleLogout}>
               {t('common.logOut')}
@@ -84,6 +94,7 @@ export function MobileHeader({ userName, periodSelector }: MobileHeaderProps) {
         </Menu>
       </Group>
       {periodSelector}
+      <FeedbackModal opened={feedbackOpen} onClose={feedback.close} />
     </div>
   );
 }

--- a/src/components/v2/AppShell/UserSection.tsx
+++ b/src/components/v2/AppShell/UserSection.tsx
@@ -1,7 +1,9 @@
-import { IconLogout, IconMoon, IconSettings, IconSun } from '@tabler/icons-react';
+import { IconLogout, IconMessage, IconMoon, IconSettings, IconSun } from '@tabler/icons-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { ActionIcon, Avatar, Group, Menu, Stack, Text, useMantineColorScheme } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { FeedbackModal } from '@/components/v2/Feedback';
 import { useAuth } from '@/context/AuthContext';
 import classes from './AppShell.module.css';
 
@@ -20,6 +22,7 @@ export function UserSection({ name, email, collapsed }: UserSectionProps) {
   const { logout } = useAuth();
   const { colorScheme, toggleColorScheme } = useMantineColorScheme();
   const isDark = colorScheme === 'dark';
+  const [feedbackOpen, feedback] = useDisclosure(false);
 
   const initials = name
     .split(' ')
@@ -57,6 +60,13 @@ export function UserSection({ name, email, collapsed }: UserSectionProps) {
             >
               {t('common.settings')}
             </Menu.Item>
+            <Menu.Item
+              leftSection={<IconMessage size={14} />}
+              onClick={feedback.open}
+              data-testid="feedback-menu-item"
+            >
+              {t('feedback.menuItem')}
+            </Menu.Item>
             <Menu.Divider />
             <Menu.Item
               data-testid="user-logout-button"
@@ -68,6 +78,7 @@ export function UserSection({ name, email, collapsed }: UserSectionProps) {
             </Menu.Item>
           </Menu.Dropdown>
         </Menu>
+        <FeedbackModal opened={feedbackOpen} onClose={feedback.close} />
       </Stack>
     );
   }
@@ -97,7 +108,14 @@ export function UserSection({ name, email, collapsed }: UserSectionProps) {
         </Menu.Target>
         <Menu.Dropdown>
           <Menu.Item leftSection={<IconSettings size={14} />} onClick={() => navigate('/settings')}>
-            Settings
+            {t('common.settings')}
+          </Menu.Item>
+          <Menu.Item
+            leftSection={<IconMessage size={14} />}
+            onClick={feedback.open}
+            data-testid="feedback-menu-item"
+          >
+            {t('feedback.menuItem')}
           </Menu.Item>
           <Menu.Divider />
           <Menu.Item
@@ -106,10 +124,11 @@ export function UserSection({ name, email, collapsed }: UserSectionProps) {
             color="red"
             onClick={handleLogout}
           >
-            Log out
+            {t('common.logOut')}
           </Menu.Item>
         </Menu.Dropdown>
       </Menu>
+      <FeedbackModal opened={feedbackOpen} onClose={feedback.close} />
       <ActionIcon
         variant="subtle"
         size="sm"

--- a/src/components/v2/Feedback/FeedbackModal.tsx
+++ b/src/components/v2/Feedback/FeedbackModal.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, Group, Modal, Stack, Text, Textarea, TextInput } from '@mantine/core';
+import { useMe } from '@/hooks/v2/useAuth';
+import { Sentry } from '@/lib/sentry';
+import { toast } from '@/lib/toast';
+
+interface FeedbackModalProps {
+  opened: boolean;
+  onClose: () => void;
+}
+
+export function FeedbackModal({ opened, onClose }: FeedbackModalProps) {
+  const { t } = useTranslation('v2');
+  const { data: user } = useMe();
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (opened) {
+      setName(user?.name ?? '');
+      setEmail(user?.email ?? '');
+      setMessage('');
+    }
+  }, [opened, user?.name, user?.email]);
+
+  const handleSubmit = async () => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      Sentry.captureFeedback({
+        name: name.trim() || undefined,
+        email: email.trim() || undefined,
+        message: trimmed,
+      });
+      toast.success({ message: t('feedback.success') });
+      onClose();
+    } catch {
+      toast.error({ message: t('feedback.error') });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={t('feedback.title')}
+      centered
+      size="md"
+      data-testid="feedback-modal"
+    >
+      <Stack gap="md">
+        <Text size="sm" c="dimmed">
+          {t('feedback.subtitle')}
+        </Text>
+        <TextInput
+          label={t('feedback.nameLabel')}
+          placeholder={t('feedback.namePlaceholder')}
+          value={name}
+          onChange={(e) => setName(e.currentTarget.value)}
+          autoComplete="name"
+        />
+        <TextInput
+          label={t('feedback.emailLabel')}
+          placeholder={t('feedback.emailPlaceholder')}
+          value={email}
+          onChange={(e) => setEmail(e.currentTarget.value)}
+          type="email"
+          autoComplete="email"
+        />
+        <Textarea
+          label={t('feedback.messageLabel')}
+          placeholder={t('feedback.messagePlaceholder')}
+          value={message}
+          onChange={(e) => setMessage(e.currentTarget.value)}
+          minRows={5}
+          autosize
+          required
+          data-testid="feedback-message"
+        />
+        <Group justify="flex-end" gap="sm">
+          <Button variant="subtle" onClick={onClose} disabled={submitting}>
+            {t('common.cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            loading={submitting}
+            disabled={!message.trim()}
+            data-testid="feedback-submit"
+          >
+            {t('feedback.submit')}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/v2/Feedback/index.ts
+++ b/src/components/v2/Feedback/index.ts
@@ -1,0 +1,1 @@
+export { FeedbackModal } from './FeedbackModal';

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,9 +3,9 @@ import { initReactI18next } from 'react-i18next';
 import { applyDayjsLocale } from '@/lib/locale';
 import deDE from './locales/v2/de-de.json';
 import en from './locales/v2/en.json';
-import nlNL from './locales/v2/nl-nl.json';
-import frFR from './locales/v2/fr-fr.json';
 import esES from './locales/v2/es-es.json';
+import frFR from './locales/v2/fr-fr.json';
+import nlNL from './locales/v2/nl-nl.json';
 import ptPT from './locales/v2/pt-pt.json';
 import pt from './locales/v2/pt.json';
 

--- a/src/locales/v2/de-de.json
+++ b/src/locales/v2/de-de.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Zugriff anfragen"
       }
     }
+  },
+  "feedback": {
+    "title": "Feedback senden",
+    "subtitle": "Einen Fehler entdeckt, eine Funktion vermisst oder etwas Komisches gesehen? Erzähl uns davon.",
+    "menuItem": "Feedback senden",
+    "nameLabel": "Name",
+    "namePlaceholder": "Dein Name",
+    "emailLabel": "E-Mail",
+    "emailPlaceholder": "name@beispiel.com",
+    "messageLabel": "Dein Feedback",
+    "messagePlaceholder": "Was möchtest du loswerden?",
+    "submit": "Feedback senden",
+    "success": "Danke — dein Feedback ist unterwegs.",
+    "error": "Dein Feedback konnte nicht gesendet werden. Bitte versuche es erneut."
   }
 }

--- a/src/locales/v2/en.json
+++ b/src/locales/v2/en.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Request Access"
       }
     }
+  },
+  "feedback": {
+    "title": "Share feedback",
+    "subtitle": "Spotted a bug, missing feature, or rough edge? Tell us what you saw.",
+    "menuItem": "Share feedback",
+    "nameLabel": "Name",
+    "namePlaceholder": "Your name",
+    "emailLabel": "Email",
+    "emailPlaceholder": "name@example.com",
+    "messageLabel": "Your feedback",
+    "messagePlaceholder": "What's on your mind?",
+    "submit": "Send feedback",
+    "success": "Thanks — your feedback is on its way.",
+    "error": "Couldn't send your feedback. Please try again."
   }
 }

--- a/src/locales/v2/es-es.json
+++ b/src/locales/v2/es-es.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Solicitar acceso"
       }
     }
+  },
+  "feedback": {
+    "title": "Comparte tu opinión",
+    "subtitle": "¿Has detectado un fallo, te falta una función o has visto algo raro? Cuéntanoslo.",
+    "menuItem": "Comparte tu opinión",
+    "nameLabel": "Nombre",
+    "namePlaceholder": "Tu nombre",
+    "emailLabel": "Email",
+    "emailPlaceholder": "nombre@ejemplo.com",
+    "messageLabel": "Tu opinión",
+    "messagePlaceholder": "¿Qué nos quieres contar?",
+    "submit": "Enviar opinión",
+    "success": "Gracias — hemos recibido tu opinión.",
+    "error": "No se ha podido enviar tu opinión. Inténtalo de nuevo."
   }
 }

--- a/src/locales/v2/fr-fr.json
+++ b/src/locales/v2/fr-fr.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Demander l'accès"
       }
     }
+  },
+  "feedback": {
+    "title": "Partager un avis",
+    "subtitle": "Vous avez repéré un bug, une fonctionnalité manquante ou un détail à revoir ? Dites-nous ce que vous avez vu.",
+    "menuItem": "Partager un avis",
+    "nameLabel": "Nom",
+    "namePlaceholder": "Votre nom",
+    "emailLabel": "E-mail",
+    "emailPlaceholder": "nom@exemple.com",
+    "messageLabel": "Votre avis",
+    "messagePlaceholder": "Que voulez-vous nous dire ?",
+    "submit": "Envoyer",
+    "success": "Merci — votre avis a bien été envoyé.",
+    "error": "Impossible d'envoyer votre avis. Veuillez réessayer."
   }
 }

--- a/src/locales/v2/nl-nl.json
+++ b/src/locales/v2/nl-nl.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Toegang aanvragen"
       }
     }
+  },
+  "feedback": {
+    "title": "Geef feedback",
+    "subtitle": "Bug ontdekt, functie gemist of iets vreemds gezien? Laat het ons weten.",
+    "menuItem": "Geef feedback",
+    "nameLabel": "Naam",
+    "namePlaceholder": "Je naam",
+    "emailLabel": "E-mail",
+    "emailPlaceholder": "naam@voorbeeld.com",
+    "messageLabel": "Je feedback",
+    "messagePlaceholder": "Wat wil je delen?",
+    "submit": "Feedback versturen",
+    "success": "Bedankt — je feedback is verstuurd.",
+    "error": "Je feedback kon niet worden verstuurd. Probeer het opnieuw."
   }
 }

--- a/src/locales/v2/pt-pt.json
+++ b/src/locales/v2/pt-pt.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Solicitar acesso"
       }
     }
+  },
+  "feedback": {
+    "title": "Enviar comentários",
+    "subtitle": "Encontrou um erro, falta-lhe alguma funcionalidade ou viu algo estranho? Diga-nos.",
+    "menuItem": "Enviar comentários",
+    "nameLabel": "Nome",
+    "namePlaceholder": "O seu nome",
+    "emailLabel": "Email",
+    "emailPlaceholder": "nome@exemplo.com",
+    "messageLabel": "Os seus comentários",
+    "messagePlaceholder": "O que gostaria de partilhar?",
+    "submit": "Enviar comentários",
+    "success": "Obrigado — os seus comentários foram enviados.",
+    "error": "Não foi possível enviar os comentários. Tente novamente."
   }
 }

--- a/src/locales/v2/pt.json
+++ b/src/locales/v2/pt.json
@@ -1809,5 +1809,19 @@
         "requestAccess": "Solicitar Acesso"
       }
     }
+  },
+  "feedback": {
+    "title": "Enviar feedback",
+    "subtitle": "Encontrou um bug, sente falta de uma funcionalidade ou viu algo estranho? Conte para nós.",
+    "menuItem": "Enviar feedback",
+    "nameLabel": "Nome",
+    "namePlaceholder": "Seu nome",
+    "emailLabel": "Email",
+    "emailPlaceholder": "nome@exemplo.com",
+    "messageLabel": "Seu feedback",
+    "messagePlaceholder": "O que você quer compartilhar?",
+    "submit": "Enviar feedback",
+    "success": "Valeu — seu feedback foi enviado.",
+    "error": "Não foi possível enviar o feedback. Tente novamente."
   }
 }


### PR DESCRIPTION
## Summary

Adds a **Share feedback** entry to the user menu (desktop sidebar + mobile header). Opens a Mantine modal with name / email / message fields and submits via `Sentry.captureFeedback()`.

Submissions land in **Sentry → Issues → User Feedback**. No new env vars — the existing DSN handles routing.

## Behavior

- Name + email **prefill from the signed-in user** but stay editable.
- Message is **required**; submit button disabled until something is typed.
- **Success:** toast confirms, modal closes.
- **Failure:** error toast, modal stays open so the user can retry without losing what they wrote.

## UX placement

- Desktop sidebar user menu (both collapsed-avatar and full-row variants).
- Mobile header user menu.

Each surface has its own `useDisclosure` instance — modal is portaled, only one is ever visible at a time, no shared-state plumbing needed.

## Translations

11 new strings under a `feedback.*` namespace. Localized natively across all **7 locales**:

| Locale | Menu item label | Submit button |
|---|---|---|
| en | Share feedback | Send feedback |
| pt | Enviar feedback | Enviar feedback |
| pt-pt | Enviar comentários | Enviar comentários |
| es-es | Comparte tu opinión | Enviar opinión |
| fr-fr | Partager un avis | Envoyer |
| de-de | Feedback senden | Feedback senden |
| nl-nl | Geef feedback | Feedback versturen |

Tone matches each locale's existing register (formal vous/Sie/você vs. informal du/je/tú).

Key parity preserved — **all 7 v2 locale files now hold 1,433 keys** (was 1,422 before) with zero drift.

## Technical notes

- `Sentry.captureFeedback({ name, email, message })` from `@sentry/react` v10.x. No `feedbackIntegration` needed (that's only for Sentry's prebuilt floating widget; we use our own UI).
- New files: `src/components/v2/Feedback/FeedbackModal.tsx` + barrel.
- Modified: `UserSection.tsx`, `MobileHeader.tsx`, all 7 locale JSONs.

## Test plan

- [x] `yarn typecheck`, `yarn vitest`, `yarn prettier`, `yarn lint`, `yarn build` all clean
- [x] Key parity verified across all 7 locales (1,433 each)
- [ ] Post-merge: open user menu → Share feedback → submit a test message → confirm it appears in Sentry → Issues → User Feedback
- [ ] Spot-check each locale's modal label tone matches the locale's overall style

🤖 Generated with [Claude Code](https://claude.com/claude-code)