### PR TITLE
fix(i18n): match resource keys when language has a region segment

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,6 +22,11 @@ void i18n.use(initReactI18next).init({
   ns: ['v2'],
   defaultNS: 'v2',
   lng: 'en',
+  // Resources are keyed lowercase ("es-es", "pt-pt", …). By default i18next
+  // normalises incoming codes per BCP-47 (lowercase language, uppercase
+  // region — so "es-es" becomes "es-ES" and misses our resource keys, falling
+  // back to English). Forcing lowercase keeps everything in one shape.
+  lowerCaseLng: true,
   fallbackLng: {
     'pt-pt': ['pt', 'en'],
     default: ['en'],


### PR DESCRIPTION
## The bug

Switching the UI language to anything with a regional segment (pt-pt, es-es, fr-fr, de-de, nl-nl) silently falls back to English. Only `pt` (Brazilian Portuguese) worked — because it has no region segment.

## Root cause

By default i18next normalises incoming language codes per BCP-47 before lookup: lowercase language, uppercase region. So `changeLanguage("es-es")` is internally rewritten to **`es-ES`**, but our resources are keyed with lowercase **`es-es`** in `i18n.ts`:

```ts
resources: {
  'es-es': { v2: esES },
  'fr-fr': { v2: frFR },
  // …
}
```

The normalised `es-ES` doesn't match `es-es` → the fallback chain kicks in → English.

## Fix

One line:

```ts
lowerCaseLng: true
```

Forces i18next to keep incoming codes lowercase, aligning with our resource keys. The dayjs locale map in `src/lib/locale.ts` is already lowercase, so dates/months/days now localise correctly too.

## Why this approach over the alternatives

- **Renaming resource keys to `es-ES`/`pt-PT`/etc.** would also work but requires updating the Settings picker, the `Language` type union, the backend if it ever stores values, and any data already in the DB for users who set a regional locale.
- **Stripping regions** (collapse `es-es` → `es`) would conflict with the whole reason these locales exist (pt-pt and pt-BR are distinct).

`lowerCaseLng` keeps the existing data shape (`'es-es'`) and just fixes the resolution.

## Test plan

- [x] `yarn typecheck`, `yarn vitest`, `yarn prettier`, `yarn lint`, `yarn build` all clean
- [ ] Post-merge: switch the language picker through each regional locale and confirm the UI actually re-renders in that language (Mantine date picker should also show localised month names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)